### PR TITLE
Avoid using the `-C` option of git in bats test

### DIFF
--- a/tests/integration/spec.bats
+++ b/tests/integration/spec.bats
@@ -73,8 +73,12 @@ function teardown() {
   [ "$status" -eq 0 ]
 
   SPEC_COMMIT=$(grep runtime-spec ${TESTDIR}/../../Godeps/Godeps.json -A 4 | grep Rev | cut -d":" -f 2 | tr -d ' "')
-  run git -C src/runtime-spec reset --hard "${SPEC_COMMIT}"
+  cd src/runtime-spec
+
+  run git reset --hard "${SPEC_COMMIT}"
   [ "$status" -eq 0 ]
+
+  cd "$HELLO_BUNDLE"
   [ -e src/runtime-spec/schema/schema.json ]
 
   run bash -c "GOPATH='$GOPATH' go get github.com/xeipuuv/gojsonschema"


### PR DESCRIPTION
The git version on RHEL7/centos7 is 1.8.3.1, which does not support `-C` option. Currently, `runc/tests/integration/spec.bats` uses the `-C` option of `git`. Please check the issue #6 .

This PR stops using the `-C` option of git in the runc bats tests.
